### PR TITLE
Allow auth to continue upon SUCCESS

### DIFF
--- a/lib/okta_session.rb
+++ b/lib/okta_session.rb
@@ -83,6 +83,8 @@ class OktaSession
       raise 'OKTA is not set up for your account! Please contact IT (#it slack channel)'
     when 'MFA_REQUIRED'
       handle_mfa(session_token(response['stateToken'], factor_id(response)))
+    when 'SUCCESS'
+      nil
     else
       raise "Unrecognized OKTA authn response status: `#{response['status']}`"
     end

--- a/okta_session.gemspec
+++ b/okta_session.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'okta_session'
-  s.version     = '0.3.0'
+  s.version     = '0.3.1'
   s.date        = '2020-06-12'
   s.summary     = 'A ruby library for Interacting with OKTA secured services via the command line'
   s.description = 'A ruby library for Interacting with OKTA secured services via the command line'


### PR DESCRIPTION
@vLukas-dev someone now gets successful auth just with username and pass, and this case errors out.