### PR TITLE
Use given sessionToken when no MFA is required

### DIFF
--- a/lib/okta_session.rb
+++ b/lib/okta_session.rb
@@ -84,7 +84,7 @@ class OktaSession
     when 'MFA_REQUIRED'
       handle_mfa(session_token(response['stateToken'], factor_id(response)))
     when 'SUCCESS'
-      nil
+      handle_mfa(response['sessionToken'])
     else
       raise "Unrecognized OKTA authn response status: `#{response['status']}`"
     end

--- a/okta_session.gemspec
+++ b/okta_session.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'okta_session'
-  s.version     = '0.3.1'
+  s.version     = '0.3.2'
   s.date        = '2020-06-12'
   s.summary     = 'A ruby library for Interacting with OKTA secured services via the command line'
   s.description = 'A ruby library for Interacting with OKTA secured services via the command line'


### PR DESCRIPTION
So apparently OKTA doesn't guarantee MFA even when it's set up for a user. This is a case where a password is enough - they give a session token immediately.

@vinted/out-of-memory 